### PR TITLE
Add MCP WebSocket client

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Updated the order of search suggestions to prioritize `is:` filters.
 * Display armor archetypes in Loadout Optimizer.
 * Support mid-season season pass track change.
+* Added a persistent MCP WebSocket client for local integrations.
 
 ## 8.83.0 <span class="changelog-date">(2025-07-27)</span>
 

--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -15,6 +15,7 @@ import { loadDimApiData } from 'app/dim-api/actions';
 import { createSaveItemInfosObserver } from 'app/inventory/observers';
 import store from 'app/store/store';
 import { lazyLoadStreamDeck, startStreamDeckConnection } from 'app/stream-deck/stream-deck';
+import { startMcpSocket } from 'app/mcp/mcp-websocket';
 import { infoLog } from 'app/utils/log';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
@@ -71,6 +72,8 @@ const i18nPromise = initi18n();
   store.dispatch(observe(createSaveItemInfosObserver()));
 
   store.dispatch(loadDimApiData());
+
+  startMcpSocket();
 
   if ($featureFlags.elgatoStreamDeck && store.getState().streamDeck.enabled) {
     await lazyLoadStreamDeck();

--- a/src/app/mcp/mcp-websocket.ts
+++ b/src/app/mcp/mcp-websocket.ts
@@ -1,0 +1,62 @@
+import { storesSelector } from 'app/inventory/selectors';
+import store from 'app/store/store';
+
+const MCP_PORT = 9130;
+const MCP_URL = `ws://localhost:${MCP_PORT}`;
+let socket: WebSocket | null = null;
+
+function sendInventory() {
+  const state = store.getState();
+  const payload = {
+    stores: storesSelector(state),
+    currencies: state.inventory.currencies,
+  };
+  try {
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify(payload));
+    }
+  } catch (e) {
+    console.error('MCP WebSocket failed to send inventory', e);
+  }
+}
+
+function handleMessage(event: MessageEvent) {
+  let message: any = null;
+  try {
+    message = JSON.parse(event.data);
+  } catch {
+    if (event.data === 'ping') {
+      sendInventory();
+      return;
+    }
+  }
+  if (message && message.type === 'ping') {
+    sendInventory();
+  }
+}
+
+function connect() {
+  socket = new WebSocket(MCP_URL);
+
+  socket.onopen = () => console.log('MCP WebSocket connected');
+
+  socket.onmessage = handleMessage;
+
+  socket.onerror = (err) => {
+    console.error('MCP WebSocket error', err);
+    try {
+      socket?.close();
+    } catch {}
+  };
+
+  socket.onclose = () => {
+    console.warn('MCP WebSocket closed, retrying in 3s');
+    setTimeout(connect, 3000);
+  };
+}
+
+export function startMcpSocket() {
+  if (!socket || socket.readyState === WebSocket.CLOSED) {
+    connect();
+  }
+}


### PR DESCRIPTION
## Summary
- hook up persistent MCP websocket to send inventory snapshots
- start MCP socket on DIM startup
- document new feature in changelog

## Testing
- `pnpm lint` *(fails: Command failed with exit code 129)*

------
https://chatgpt.com/codex/tasks/task_e_68897bb2b4cc8322bdbbc149a2d8a8a6