### PR TITLE
Add weapon summary output over MCP WebSocket

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Display armor archetypes in Loadout Optimizer.
 * Support mid-season season pass track change.
 * Added a persistent MCP WebSocket client for local integrations.
+* WebSocket now streams a concise weapon summary with perk rolls for AI tools.
 
 ## 8.83.0 <span class="changelog-date">(2025-07-27)</span>
 


### PR DESCRIPTION
## Summary
- build concise weapon summary with perks via `buildSocketNames`
- send weapon summary after inventory over MCP WebSocket
- mention new behavior in changelog

## Testing
- `pnpm fix`
- `pnpm test` *(fails: ENOENT manifest-cache)*

------
https://chatgpt.com/codex/tasks/task_e_6889b395e5c88322884ea27b55754a26