### PR TITLE
Add unified item summary over MCP socket

### DIFF
--- a/src/app/mcp/mcp-websocket.ts
+++ b/src/app/mcp/mcp-websocket.ts
@@ -14,11 +14,9 @@ import {
 } from 'app/inventory/spreadsheets';
 import type { DimStore } from 'app/inventory/store-types';
 import { getStore } from 'app/inventory/stores-helpers';
-import { D1_StatHashes } from 'app/search/d1-known-values';
 import store from 'app/store/store';
 import { getItemKillTrackerInfo } from 'app/utils/item-utils';
 import { countEnhancedPerks } from 'app/utils/socket-utils';
-import { StatHashes } from 'data/d2/generated-enums';
 
 const MCP_PORT = 9130;
 const MCP_URL = `wss://localhost:${MCP_PORT}`;
@@ -29,7 +27,7 @@ function sleep(ms: number) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-function buildWeaponSummary(
+function buildItemSummary(
   item: DimItem,
   getTag: (item: DimItem) => TagValue | undefined,
   getNotes: (item: DimItem) => string | undefined,
@@ -46,9 +44,16 @@ function buildWeaponSummary(
   const killTracker = getItemKillTrackerInfo(item);
 
   return {
+    id: item.id,
+    hash: item.hash,
     name: item.name,
     type: item.typeName,
     tier: item.tier,
+    bucketHash: item.bucket.hash,
+    bucketName: item.bucket.name,
+    classType: item.classTypeNameLocalized,
+    equipped: item.equipped,
+    exotic: item.isExotic,
     element: item.element?.displayProperties.name,
     power: item.power,
     stats,
@@ -63,7 +68,7 @@ function buildWeaponSummary(
   };
 }
 
-async function sendWeapons() {
+async function sendItems() {
   const state = store.getState();
   const allItems = allItemsSelector(state);
   const getTag = getTagSelector(state);
@@ -72,17 +77,12 @@ async function sendWeapons() {
   const statNames = csvStatNamesForDestinyVersion(destinyVersion);
   const stores = storesSelector(state);
 
-  const weapons = allItems
-    .filter(
-      (item) =>
-        item.primaryStat &&
-        (item.primaryStat.statHash === D1_StatHashes.Attack ||
-          item.primaryStat.statHash === StatHashes.Attack),
-    )
-    .map((item) => buildWeaponSummary(item, getTag, getNotes, statNames, stores));
+  const items = allItems
+    .filter((item) => item.bucket.inWeapons || item.bucket.inArmor)
+    .map((item) => buildItemSummary(item, getTag, getNotes, statNames, stores));
 
   if (socket?.readyState === WebSocket.OPEN) {
-    socket.send(JSON.stringify({ type: 'weapons', data: weapons }));
+    socket.send(JSON.stringify({ type: 'items', data: items }));
   }
 }
 
@@ -159,14 +159,14 @@ function handleMessage(event: MessageEvent) {
   } catch {
     if (event.data === 'ping') {
       sendInventory();
-      sendWeapons();
+      sendItems();
       return;
     }
   }
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   if (message && message.type === 'ping') {
     sendInventory();
-    sendWeapons();
+    sendItems();
   }
 }
 
@@ -179,7 +179,7 @@ function connect() {
       socket?.send(JSON.stringify({ type: 'hello' }));
     } catch {}
     await sendInventory();
-    await sendWeapons();
+    await sendItems();
   };
 
   socket.onmessage = handleMessage;


### PR DESCRIPTION
## Summary
- combine weapon and armor summaries into a single item list
- send the new `items` payload instead of `weapons`

## Testing
- `pnpm fix`
- `pnpm test` *(fails: ENOENT manifest-cache)*

------
https://chatgpt.com/codex/tasks/task_e_688ac3111cd883228a4ce0107ea4e913