### PR TITLE
Simplify MCP data transfer

### DIFF
--- a/MCP Server/testserver.py
+++ b/MCP Server/testserver.py
@@ -1,170 +1,24 @@
 import asyncio
-import websockets
 import json
-import logging
-import ssl
-from pathlib import Path
+import websockets
 
-# Logging setup
-logging.basicConfig(level=logging.INFO, format='%(message)s')
-logger = logging.getLogger(__name__)
-
-PORT = 9130
-CERT_PATH = "/Users/maxschecter/Desktop/DIM-MCP/cert.pem"
-KEY_PATH = "/Users/maxschecter/Desktop/DIM-MCP/key.pem"
-OUTPUT_PATH = Path.home() / "Desktop" / "dim_inventory.json"
-
-aSYNC_MARKER = object()
-
-async def handle_client(websocket):
-    logger.info(f"✅ DIM connected from: {websocket.remote_address}")
-    # Buffer structure for new protocol
-    state = {
-        "stores_expected": None,
-        "stores_received": {},   # storeIndex -> {chunks: dict, total: int}
-        "stores_final": {},      # storeIndex -> parsed store object
-        "currencies": None,
-        "weapons": None,
-    }
+async def handle_item_data(websocket):
+    data = await websocket.recv()
+    print(f"Received {len(data)} bytes of data from DIM.")
     try:
-        while True:
-            try:
-                message = await asyncio.wait_for(websocket.recv(), timeout=180)
-            except asyncio.TimeoutError:
-                logger.warning("⏱️ No message from DIM within timeout window; closing")
-                break
-
-            # Parse JSON
-            try:
-                msg = json.loads(message)
-            except json.JSONDecodeError:
-                logger.info(f"📝 Received non-JSON message: {message}")
-                continue
-
-            if not isinstance(msg, dict):
-                continue
-
-            mtype = msg.get("type")
-
-            # Client hello (no reply needed)
-            if mtype == "hello":
-                logger.info("👋 Client said hello; waiting for start...")
-                continue
-
-            # Start: tells us how many stores to expect
-            if mtype == "inventoryStart":
-                state["stores_expected"] = int(msg.get("storeCount", 0))
-                logger.info(f"🟢 Start: expecting {state['stores_expected']} stores")
-                continue
-
-            # Currencies payload
-            if mtype == "currencies":
-                state["currencies"] = msg.get("data")
-                logger.info("💰 Currencies received")
-                continue
-
-            # Per-store chunk
-            if mtype == "storeChunk":
-                idx = int(msg["storeIndex"])  # zero-based
-                total = int(msg["totalChunks"])
-                chunk_idx = int(msg["chunkIndex"])
-                data = msg["data"]
-
-                buf = state["stores_received"].setdefault(idx, {"chunks": {}, "total": total})
-                buf["chunks"][chunk_idx] = data
-                buf["total"] = total  # keep latest total
-                logger.info(f"📦 Store {idx}: received chunk {chunk_idx+1}/{total}")
-
-                # If this store is complete, parse & stash
-                if len(buf["chunks"]) == buf["total"]:
-                    ordered = [buf["chunks"][i] for i in range(buf["total"])]
-                    s_json = "".join(ordered)
-                    try:
-                        store_obj = json.loads(s_json)
-                        state["stores_final"][idx] = store_obj
-                        logger.info(f"✅ Store {idx} assembled")
-                    except json.JSONDecodeError:
-                        logger.error(f"❌ Failed to decode store {idx} JSON; discarding")
-                        state["stores_received"].pop(idx, None)
-                        continue
-
-                # If all stores done, write final file
-                expected = state["stores_expected"]
-                if expected is not None and len(state["stores_final"]) == expected:
-                    stores_ordered = [state["stores_final"][i] for i in range(expected)]
-                    payload = {
-                        "stores": stores_ordered,
-                        "currencies": state["currencies"],
-                        "weapons": state["weapons"],
-                    }
-                    with open(OUTPUT_PATH, "w") as f:
-                        json.dump(payload, f, indent=2)
-                    logger.info(f"📁 Saved full inventory with {expected} stores to: {OUTPUT_PATH}")
-                    # Optionally ack
-                    await websocket.send(json.dumps({"type": "ack", "stores": expected}))
-                    # Reset to allow another cycle if needed
-                    state = {
-                        "stores_expected": None,
-                        "stores_received": {},
-                        "stores_final": {},
-                        "currencies": None,
-                        "weapons": None,
-                    }
-                continue
-
-            if mtype == "weapons":
-                state["weapons"] = msg.get("data")
-                weapons_output_path = Path.home() / "Desktop" / "dim_weapons.json"
-                with open(weapons_output_path, "w") as f:
-                    json.dump(state["weapons"], f, indent=2)
-                logger.info(f"📁 Saved weapons summary to: {weapons_output_path}")
-                logger.info("🗃️ Weapons summary received")
-                continue
-
-            # Optional: ack logging
-            if mtype == "pong":
-                logger.info("🔁 Received pong from client")
-                continue
-    except websockets.exceptions.ConnectionClosed as e:
-        logger.info(f"❌ DIM disconnected (code={getattr(e, 'code', '?')}, reason={getattr(e, 'reason', '')})")
-    except Exception as e:
-        logger.error(f"🚨 WebSocket error: {e}")
+        items = json.loads(data)
+    except json.JSONDecodeError as e:
+        print(f"Error: Received invalid JSON data - {e}")
+        return
+    with open("items.json", "w") as f:
+        json.dump(items, f, indent=2)
+    print("Saved inventory data to items.json")
 
 async def main():
-    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-    ssl_context.check_hostname = False
-    ssl_context.verify_mode = ssl.CERT_NONE
-
-    try:
-        ssl_context.load_cert_chain(CERT_PATH, KEY_PATH)
-        logger.info("🔒 Using SSL certificates from DIM")
-    except FileNotFoundError:
-        logger.error("❌ SSL certificates not found. Run DIM to generate them.")
-        return
-    except Exception as e:
-        logger.error(f"❌ SSL setup error: {e}")
-        return
-
-    logger.info(f"🚀 Secure WebSocket server started on wss://localhost:{PORT}")
-    logger.info("Waiting for DIM to connect...\n")
-
-    try:
-        async with websockets.serve(
-            handle_client,
-            "localhost",
-            PORT,
-            ssl=ssl_context,
-            ping_interval=None,  # disable protocol pings
-            close_timeout=10,
-            max_size=None,       # accept messages of any size (our chunks are ~2 MB)
-            max_queue=64,        # buffer more frames if needed
-        ):
-            await asyncio.Future()  # Run forever
-    except Exception as e:
-        logger.error(f"❌ Server failed to start: {e}")
+    async with websockets.serve(handle_item_data, "localhost", 8765):
+        print("Test server running on ws://localhost:8765 ...")
+        await asyncio.Future()
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        logger.info("\n👋 Shutting down server...")
+    asyncio.run(main())
+

--- a/src/app/mcp/mcp-websocket.ts
+++ b/src/app/mcp/mcp-websocket.ts
@@ -1,204 +1,166 @@
 /* eslint-disable no-console */
-import type { TagValue } from 'app/inventory/dim-item-info';
-import type { DimItem } from 'app/inventory/item-types';
+import { DimItem } from 'app/inventory/item-types';
+import { storesSelector } from 'app/inventory/selectors';
+import { store } from 'app/store/store';
 import {
-  allItemsSelector,
-  getNotesSelector,
-  getTagSelector,
-  storesSelector,
-} from 'app/inventory/selectors';
-import {
-  buildSocketNames,
-  buildSocketNamesByColumn,
-  csvStatNamesForDestinyVersion,
-} from 'app/inventory/spreadsheets';
-import type { DimStore } from 'app/inventory/store-types';
-import { getStore } from 'app/inventory/stores-helpers';
-import store from 'app/store/store';
-import { getItemKillTrackerInfo } from 'app/utils/item-utils';
-import { countEnhancedPerks } from 'app/utils/socket-utils';
+  getDisplayedItemSockets,
+  getSocketsByIndexes,
+  isKillTrackerSocket,
+} from 'app/utils/socket-utils';
 
-const MCP_PORT = 9130;
-const MCP_URL = `wss://localhost:${MCP_PORT}`;
-let socket: WebSocket | null = null;
-let sending = false;
+const socket = new WebSocket('ws://localhost:8765');
 
-function sleep(ms: number) {
-  return new Promise((r) => setTimeout(r, ms));
-}
+socket.addEventListener('open', () => {
+  console.log('MCP: WebSocket connection opened, preparing data...');
+  sendInventory();
+});
 
-function buildItemSummary(
-  item: DimItem,
-  getTag: (item: DimItem) => TagValue | undefined,
-  getNotes: (item: DimItem) => string | undefined,
-  statNames: Map<number, string>,
-  stores: readonly DimStore[],
-) {
-  const stats: Record<string, number> = {};
-  for (const stat of item.stats ?? []) {
-    const name = statNames.get(stat.statHash) ?? stat.displayProperties.name;
-    stats[name] = stat.value;
-  }
-
-  const store = getStore(stores, item.owner);
-  const killTracker = getItemKillTrackerInfo(item);
-
-  return {
-    id: item.id,
-    hash: item.hash,
-    name: item.name,
-    type: item.typeName,
-    tier: item.tier,
-    bucketHash: item.bucket.hash,
-    bucketName: item.bucket.name,
-    classType: item.classTypeNameLocalized,
-    equipped: item.equipped,
-    exotic: item.isExotic,
-    element: item.element?.displayProperties.name,
-    power: item.power,
-    stats,
-    perks: buildSocketNames(item),
-    perkColumns: buildSocketNamesByColumn(item),
-    owner: store?.name ?? item.owner,
-    enhancedPerks: item.sockets ? countEnhancedPerks(item.sockets) : 0,
-    craftedLevel: item.craftedInfo?.level,
-    killTracker: killTracker?.count,
-    tag: getTag(item),
-    notes: getNotes(item),
-  };
-}
-
-async function sendItems() {
+function sendInventory() {
   const state = store.getState();
-  const allItems = allItemsSelector(state);
-  const getTag = getTagSelector(state);
-  const getNotes = getNotesSelector(state);
-  const destinyVersion = allItems[0]?.destinyVersion ?? 2;
-  const statNames = csvStatNamesForDestinyVersion(destinyVersion);
   const stores = storesSelector(state);
-
-  const items = allItems
-    .filter((item) => item.bucket.inWeapons || item.bucket.inArmor)
-    .map((item) => buildItemSummary(item, getTag, getNotes, statNames, stores));
-
-  if (socket?.readyState === WebSocket.OPEN) {
-    socket.send(JSON.stringify({ type: 'items', data: items }));
-  }
-}
-
-async function sendInventory() {
-  if (sending) {
-    console.log('🔄 Skipping sendInventory — already in progress');
+  if (!stores.length) {
+    console.log('MCP: Inventory not loaded yet, retrying in 1s...');
+    setTimeout(sendInventory, 1000);
     return;
   }
-  sending = true;
-  console.log('🚀 Sending inventory data (per-store streaming)...');
 
-  const state = store.getState();
-  const stores = storesSelector(state);
-  const currencies = state.inventory.currencies;
+  let allItems: DimItem[] = [];
+  for (const dimStore of stores) {
+    const gearItems = dimStore.items.filter((i) => i.bucket.inWeapons || i.bucket.inArmor);
+    allItems = allItems.concat(gearItems);
+  }
 
-  try {
-    // 1) Tell server how many stores to expect
-    socket?.send(JSON.stringify({ type: 'inventoryStart', storeCount: stores.length }));
-    await sleep(10);
+  const itemsData = allItems.map((item) => buildItemData(item));
+  socket.send(JSON.stringify(itemsData));
+  console.log(`MCP: Sent ${itemsData.length} item entries to the server.`);
+}
 
-    // 2) Send currencies separately (small)
-    socket?.send(JSON.stringify({ type: 'currencies', data: currencies }));
-    await sleep(10);
+function buildItemData(item: DimItem) {
+  const itemObj: any = {
+    name: item.name,
+    type: item.typeName,
+    class:
+      item.classTypeNameLocalized?.toLowerCase() === 'unknown'
+        ? 'Any'
+        : item.classTypeNameLocalized,
+    rarity: item.rarity,
+  };
 
-    // 3) Send each store as its own chunked blob
-    const CHUNK_SIZE = 2 * 1024 * 1024; // 2 MB
+  if (item.power !== undefined) {
+    itemObj.power = item.power;
+  } else if (item.primaryStat) {
+    itemObj.power = item.primaryStat.value;
+  }
 
-    for (let i = 0; i < stores.length; i++) {
-      const store = stores[i];
-      const seen = new WeakSet<object>();
-      const sjson = JSON.stringify(store, function (_: any, value: any) {
-        if (typeof value === 'object' && value !== null) {
-          if (seen.has(value as object)) {
-            return '[Circular]';
-          }
-          seen.add(value as object);
-        }
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return value;
-      });
+  if (item.element) {
+    itemObj.element = item.element.displayProperties.name;
+  }
 
-      const totalChunks = Math.ceil(sjson.length / CHUNK_SIZE) || 1;
-      for (let c = 0; c < totalChunks; c++) {
-        const chunk = sjson.slice(c * CHUNK_SIZE, (c + 1) * CHUNK_SIZE);
-        const message = JSON.stringify({
-          type: 'storeChunk',
-          storeIndex: i,
-          chunkIndex: c,
-          totalChunks,
-          data: chunk,
+  if (item.stats) {
+    const stats: Record<string, number> = {};
+    for (const stat of item.stats) {
+      stats[stat.displayProperties.name] = stat.value;
+    }
+    itemObj.stats = stats;
+  }
+
+  if (item.energy) {
+    const energyTypeMap: Record<number, string> = {
+      1: 'Arc',
+      2: 'Solar',
+      3: 'Void',
+      6: 'Stasis',
+    };
+    const { energyType, energyCapacity } = item.energy;
+    itemObj.energy = {
+      type: energyTypeMap[energyType] || 'Any',
+      capacity: energyCapacity,
+    };
+  }
+
+  const sockets = getDisplayedItemSockets(item, true);
+  const perksByColumn: string[][] = [];
+  const socketCategories: Record<string, string[]> = {};
+
+  if (sockets) {
+    const { intrinsicSocket, perks, modSocketsByCategory } = sockets;
+
+    if (intrinsicSocket) {
+      if (
+        isKillTrackerSocket(intrinsicSocket) &&
+        intrinsicSocket.plugged?.plugDef.displayProperties.name
+      ) {
+        perksByColumn.push([intrinsicSocket.plugged.plugDef.displayProperties.name]);
+      } else {
+        const names = intrinsicSocket.plugOptions.map((p) => {
+          const name = p.plugDef.displayProperties.name;
+          return intrinsicSocket.plugged?.plugDef.hash === p.plugDef.hash ? `${name}*` : name;
         });
-        if (socket?.readyState === WebSocket.OPEN) {
-          socket.send(message);
-          await sleep(20); // throttle a bit to avoid buffer backpressure
+        perksByColumn.push(names);
+      }
+    }
+
+    if (perks) {
+      const perkSockets = getSocketsByIndexes(item.sockets!, perks.socketIndexes);
+      for (const socket of perkSockets) {
+        if (isKillTrackerSocket(socket) && socket.plugged?.plugDef.displayProperties.name) {
+          perksByColumn.push([socket.plugged.plugDef.displayProperties.name]);
+        } else {
+          const names = socket.plugOptions.map((p) => {
+            const name = p.plugDef.displayProperties.name;
+            return socket.plugged?.plugDef.hash === p.plugDef.hash ? `${name}*` : name;
+          });
+          perksByColumn.push(names);
         }
       }
-      console.log(`📤 Store ${i} sent in ${Math.ceil(sjson.length / CHUNK_SIZE) || 1} chunks`);
-      await sleep(30);
     }
 
-    console.log('✅ All stores sent');
-  } catch (err) {
-    console.error('❌ sendInventory failed:', err);
-  } finally {
-    sending = false;
-  }
-}
-
-function handleMessage(event: MessageEvent) {
-  let message: any = null;
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    message = JSON.parse(String(event.data));
-  } catch {
-    if (event.data === 'ping') {
-      sendInventory();
-      sendItems();
-      return;
+    for (const [category, socketList] of modSocketsByCategory) {
+      const categoryName = category.category.displayProperties.name;
+      const names: string[] = [];
+      for (const socket of socketList) {
+        if (isKillTrackerSocket(socket) && socket.plugged?.plugDef.displayProperties.name) {
+          names.push(socket.plugged.plugDef.displayProperties.name);
+        } else {
+          for (const p of socket.plugOptions) {
+            const name = p.plugDef.displayProperties.name;
+            names.push(socket.plugged?.plugDef.hash === p.plugDef.hash ? `${name}*` : name);
+          }
+        }
+      }
+      if (names.length) {
+        socketCategories[categoryName] = names;
+      }
     }
   }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  if (message && message.type === 'ping') {
-    sendInventory();
-    sendItems();
+
+  if (perksByColumn.length) {
+    itemObj.perksByColumn = perksByColumn;
   }
+  if (Object.keys(socketCategories).length) {
+    itemObj.socketCategories = socketCategories;
+  }
+
+  if (item.masterworkInfo) {
+    const mw = item.masterworkInfo;
+    const mwObj: any = { tier: mw.tier };
+    if (mw.stats?.length) {
+      mwObj.stats = mw.stats.map((s) => ({ name: s.name, value: s.value }));
+    }
+    itemObj.masterwork = mwObj;
+  }
+
+  return itemObj;
 }
 
-function connect() {
-  socket = new WebSocket(MCP_URL);
+socket.addEventListener('error', (evt) => {
+  console.error('MCP: WebSocket error', evt);
+});
 
-  socket.onopen = async () => {
-    console.log('MCP WebSocket connected');
-    try {
-      socket?.send(JSON.stringify({ type: 'hello' }));
-    } catch {}
-    await sendInventory();
-    await sendItems();
-  };
-
-  socket.onmessage = handleMessage;
-
-  socket.onerror = (err) => {
-    console.error('MCP WebSocket error', err);
-    try {
-      socket?.close();
-    } catch {}
-  };
-
-  socket.onclose = () => {
-    console.warn('MCP WebSocket closed, retrying in 3s');
-    setTimeout(connect, 3000);
-  };
-}
+socket.addEventListener('close', () => {
+  console.log('MCP: WebSocket connection closed.');
+});
 
 export function startMcpSocket() {
-  if (!socket || socket.readyState === WebSocket.CLOSED) {
-    connect();
-  }
+  // intentional noop - socket connection starts on import
 }


### PR DESCRIPTION
## Summary
- replace chunky WebSocket inventory sender with simple item dump
- simplify Python test server to accept one JSON blob

## Testing
- `pnpm test` *(fails: ENOENT: no such file or directory, scandir '/workspace/DIM-MCP/manifest-cache')*

------
https://chatgpt.com/codex/tasks/task_e_688ad20dcb348322b638a1667d8c59a1