### PR TITLE
Replace perk asterisk marker

### DIFF
--- a/src/app/mcp/mcp-websocket.ts
+++ b/src/app/mcp/mcp-websocket.ts
@@ -72,7 +72,7 @@ function buildWeaponPerkColumns(item: DimItem): string[][] {
           name += ' (Enhanced)';
         }
         if (socket.plugged?.plugDef.hash === p.plugDef.hash) {
-          name += '*';
+          name += ' (equipped)';
         }
         return name;
       }),


### PR DESCRIPTION
## Summary
- mark equipped perk with `(equipped)` text instead of `*`

## Testing
- `npm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688af1d520b88322afbf257e0b28a428