### PR TITLE
Include item IDs in MCP websocket payloads

### DIFF
--- a/src/app/mcp/mcp-websocket.ts
+++ b/src/app/mcp/mcp-websocket.ts
@@ -36,6 +36,7 @@ function buildBaseItemSummary(
   const store = getStore(stores, item.owner);
 
   return {
+    id: item.id,
     name: item.name,
     type: item.typeName,
     gearTier: item.tier,


### PR DESCRIPTION
## Summary
- include the DIM item instance ID when sending weapons and armor over the MCP websocket

## Testing
- `pnpm test` *(fails: ENOENT manifest-cache)*

------
https://chatgpt.com/codex/tasks/task_e_688af56924b0832286ad793205f54a70