### PR TITLE
Include weapon masterwork info in MCP websocket

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Support mid-season season pass track change.
 * Added a persistent MCP WebSocket client for local integrations.
 * WebSocket now streams a concise weapon summary with perk rolls for AI tools.
+* WebSocket weapon summaries include masterwork info.
 
 ## 8.83.0 <span class="changelog-date">(2025-07-27)</span>
 

--- a/src/app/mcp/mcp-websocket.ts
+++ b/src/app/mcp/mcp-websocket.ts
@@ -88,6 +88,8 @@ function buildWeaponSummary(
     perks: buildWeaponPerkColumns(item),
     craftedLevel: item.craftedInfo?.level,
     killTracker: getItemKillTrackerInfo(item)?.count,
+    masterwork: item.masterwork,
+    masterworkTier: item.masterworkInfo?.tier,
   };
 }
 


### PR DESCRIPTION
## Summary
- add masterwork boolean and tier to weapon summaries
- document the change in CHANGELOG

## Testing
- `pnpm test` *(fails: precache manifest)*

------
https://chatgpt.com/codex/tasks/task_e_688af768c8d08322b0cc18dc1d7b23c9