### PR TITLE
Add weapon masterwork details to MCP websocket

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added a persistent MCP WebSocket client for local integrations.
 * WebSocket now streams a concise weapon summary with perk rolls for AI tools.
 * WebSocket weapon summaries include masterwork info.
+* WebSocket weapon summaries expose masterwork type and tier fields.
 
 ## 8.83.0 <span class="changelog-date">(2025-07-27)</span>
 

--- a/src/app/mcp/mcp-websocket.ts
+++ b/src/app/mcp/mcp-websocket.ts
@@ -12,7 +12,11 @@ import type { DimStore } from 'app/inventory/store-types';
 import { getStore } from 'app/inventory/stores-helpers';
 import { D1_StatHashes } from 'app/search/d1-known-values';
 import store from 'app/store/store';
-import { getItemKillTrackerInfo, isKillTrackerSocket } from 'app/utils/item-utils';
+import {
+  getItemKillTrackerInfo,
+  getMasterworkStatNames,
+  isKillTrackerSocket,
+} from 'app/utils/item-utils';
 import { getSocketsByIndexes, getWeaponSockets, isEnhancedPerk } from 'app/utils/socket-utils';
 import { StatHashes } from 'data/d2/generated-enums';
 
@@ -88,6 +92,7 @@ function buildWeaponSummary(
     perks: buildWeaponPerkColumns(item),
     craftedLevel: item.craftedInfo?.level,
     killTracker: getItemKillTrackerInfo(item)?.count,
+    masterworkType: getMasterworkStatNames(item.masterworkInfo),
     masterwork: item.masterwork,
     masterworkTier: item.masterworkInfo?.tier,
   };


### PR DESCRIPTION
## Summary
- expose masterwork type and tier in weapon summaries
- document the change in the changelog

## Testing
- `pnpm fix` *(fails: Command failed with exit code 1)*
- `pnpm test` *(fails: ENOENT no such file or directory manifest-cache)*

------
https://chatgpt.com/codex/tasks/task_e_688b08dfa5ec832295cc0092dbf49720